### PR TITLE
Fix smb connect segfaulting when no options are passed

### DIFF
--- a/src/remotes.c
+++ b/src/remotes.c
@@ -172,9 +172,14 @@ remote_smb(char *address, char *options)
 	char *roptions = (char *)NULL;
 
 	if (ruser) {
-		roptions = (char *)xnmalloc(strlen(ruser) + strlen(options) + 11,
-															sizeof(char));
-		sprintf(roptions, "username=%s,%s", ruser, options);
+		if (options) {
+			roptions = (char *)xnmalloc(strlen(ruser) + strlen(options) + 11, sizeof(char));
+			sprintf(roptions, "username=%s,%s", ruser, options);
+		} else {
+			roptions = (char *)xnmalloc(strlen(ruser) + 11, sizeof(char));
+			sprintf(roptions, "username=%s", ruser);
+		}
+
 		free_options = 1;
 	} else
 		roptions = options;


### PR DESCRIPTION
Currently when trying to connect with `net smb://user@server/path` the
strlen on options will segfault.
This PR introduces a check if options are empty and ignores them if
they are.

My C-fu isn't exactly the strongest so feel free to use a more elegant 
solution.