### PR TITLE
Fixes data dirs ending up as initial path

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1514,6 +1514,9 @@ load_pinned_dir(void)
 void
 get_path_programs(void)
 {
+	char cwd[PATH_MAX] = "";
+	getcwd(cwd, sizeof(cwd));
+
 	struct dirent ***commands_bin = (struct dirent ***)xnmalloc(
 	    path_n, sizeof(struct dirent));
 	int i, j, l = 0, total_cmd = 0;
@@ -1536,6 +1539,7 @@ get_path_programs(void)
 		if (cmd_n[i] > 0)
 			total_cmd += (size_t)cmd_n[i];
 	}
+	xchdir(cwd, NO_TITLE);
 
 	/* Add internal commands */
 	size_t internal_cmd_n = 0;


### PR DESCRIPTION
Due to how get_path_programs enumerates bins, it'll always end up pushing
the last bin folder to the top, resulting in the start directory not
being cwd as would be expected.

This PR xchdirs back to what cwd was before enumerating bins.

This was introduced in cbc8abcd53dec4a3c6aa60e7de13a2924a5a732b (so only concerns master) when get_path_programs was moved above the workspace initial path logic. It might be possible to just move it below that again instead.