### PR TITLE
Added CMake for the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.8)
+project(CLIFM)
+
+file(GLOB SRC_FILES src/*.c)
+file(GLOB HDR_FILES src/*.h)
+
+add_executable(clifm
+  ${SRC_FILES}
+  ${HDR_FILES}
+)
+target_link_libraries(clifm PUBLIC
+  readline
+  acl
+  cap
+  magic
+)


### PR DESCRIPTION
Solves https://github.com/leo-arch/clifm/issues/53 by creating a proposal for using _CMake_ for the build system. Currently, the dependent libraries are not managed by this build, but these could be added as _git submodules_ and appended to the build process for being able to port this application even easier for other OS.

# Instructions for building

```bash
cmake . -B../clifm-build
cmake --build ../clifm-build -j`nproc`
```
