### PR TITLE
macOS build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ LIBS_Linux ?= -lreadline -lacl -lcap -lmagic
 LIBS_FreeBSD ?= -I/usr/local/include -L/usr/local/lib -lreadline -lintl -lmagic
 LIBS_NetBSD ?= -I/usr/pkg/include -L/usr/pkg/lib -Wl,-R/usr/pkg/lib -lreadline -lintl -lmagic
 LIBS_OpenBSD ?= -I/usr/local/include -L/usr/local/lib -lereadline -lintl -lmagic
+LIBS_Darwin ?= -I/opt/local/include -L/opt/local/lib -lreadline -lintl -lmagic
 
 build: $(SRC) $(HEADERS)
 	@printf "Detected operating system: %s\n" "$(OS)"

--- a/src/aux.c
+++ b/src/aux.c
@@ -203,7 +203,7 @@ normalize_path(char *src, size_t src_len)
 
 		case 2:
 			if (ptr[0] == '.' && ptr[1] == '.') {
-#if !defined(__HAIKU__) && !defined(_BE_POSIX)
+#if !defined(__HAIKU__) && !defined(_BE_POSIX) && !defined(__APPLE__)
 				const char *slash = memrchr(res, '/', res_len);
 #else
 				const char *slash = strrchr(res, '/');

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -45,6 +45,9 @@
 # ifdef __OpenBSD__
 #  define _BSD_SOURCE
 # endif
+# ifdef __APPLE__
+#  define _DARWIN_C_SOURCE
+# endif
 #endif
 
 /* Setting GLOB_BRACE to ZERO disables support for GLOB_BRACE if not
@@ -82,6 +85,8 @@
 # include <sys/param.h>
 # include <sys/syslimits.h>
 # define BSD_KQUEUE
+#elif defined(__APPLE__)
+# include <sys/types.h>
 #endif /* __linux__ */
 
 #include "init.h"

--- a/src/listing.c
+++ b/src/listing.c
@@ -479,7 +479,7 @@ set_long_attribs(const int n, const struct stat *attr)
 {
 	file_info[n].uid = attr->st_uid;
 	file_info[n].gid = attr->st_gid;
-	file_info[n].ltime = (time_t)attr->st_mtim.tv_sec;
+	file_info[n].ltime = (time_t)attr->st_mtime;
 	file_info[n].mode = attr->st_mode;
 	file_info[n].rdev = attr->st_rdev;
 
@@ -1924,7 +1924,7 @@ list_dir(void)
 			file_info[n].mode = attr.st_mode;
 
 			if (long_view) {
-				file_info[n].ltime = (time_t)attr.st_mtim.tv_sec;
+				file_info[n].ltime = (time_t)attr.st_mtime;
 			}
 		} else {
 			file_info[n].type = DT_UNKNOWN;

--- a/src/main.c
+++ b/src/main.c
@@ -739,8 +739,8 @@ check_cpu_os(void)
 	exit(EXIT_FAILURE);
 #endif
 
-#if !defined(__linux__) && !defined(__FreeBSD__) \
-&& !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__HAIKU__)
+#if !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__) \
+&& !defined(__OpenBSD__) && !defined(__HAIKU__) && !defined(__APPLE__)
 	fprintf(stderr, _("%s: Unsupported operating system\n"), PROGRAM_NAME);
 	exit(EXIT_FAILURE);
 #endif

--- a/src/properties.c
+++ b/src/properties.c
@@ -260,7 +260,7 @@ get_properties(char *filename, const int dsize)
 	nlink_t link_n = attr.st_nlink;
 
 	/* Get modification time */
-	time_t time = (time_t)attr.st_mtim.tv_sec;
+	time_t time = (time_t)attr.st_mtime;
 	struct tm tm;
 	localtime_r(&time, &tm);
 	char mod_time[128];
@@ -325,7 +325,7 @@ get_properties(char *filename, const int dsize)
 
 	/* Stat information */
 	/* Last access time */
-	time = (time_t)attr.st_atim.tv_sec;
+	time = (time_t)attr.st_atime;
 	localtime_r(&time, &tm);
 	char access_time[128];
 
@@ -337,7 +337,7 @@ get_properties(char *filename, const int dsize)
 	}
 
 	/* Last properties change time */
-	time = (time_t)attr.st_ctim.tv_sec;
+	time = (time_t)attr.st_ctime;
 	localtime_r(&time, &tm);
 	char change_time[128];
 	if (time) {

--- a/src/selection.c
+++ b/src/selection.c
@@ -33,7 +33,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#if defined(__linux__) || defined(__HAIKU__)
+#if defined(__linux__) || defined(__HAIKU__) || defined(__APPLE__)
 #ifdef __TINYC__
 /* Silence a tcc warning. We don't use CTRL anyway */
 #undef CTRL


### PR DESCRIPTION
Fix all build errors except `memrchr`, which does not exist on macOS. See https://www.gnu.org/software/gnulib/manual/html_node/memrchr.html.

```
cc -o clifm src/*.c -I/opt/local/include -L/opt/local/lib
src/aux.c:207:25: error: implicit declaration of function 'memrchr' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                                const char *slash = memrchr(res, '/', res_len);
                                                    ^
src/aux.c:207:25: note: did you mean 'memchr'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/string.h:70:7: note: 'memchr' declared here
void    *memchr(const void *__s, int __c, size_t __n);
         ^
```