### PR TITLE
Add macOS CMake test workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,10 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: l2dy/setup-macports@v1
 
     - name: Install dependencies
-      run: sudo port -N install cmake pkgconfig readline gettext libmagic
+      run: |
+        curl -fsSLO "https://github.com/l2dy/clifm-ci-files/releases/download/v0.0.2/clifm-bootstrap.mpkg"
+        sudo installer -pkg clifm-bootstrap.mpkg -target /
+        echo "/opt/local/bin" >> $GITHUB_PATH
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,34 @@
+name: CMake Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: l2dy/setup-macports@v1
+
+    - name: Install dependencies
+      run: sudo port -N install cmake pkgconfig readline gettext libmagic
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
Test macOS build with CMake.

The first commit uses l2dy/setup-macports to install MacPorts.

The second commit replaces it with a pre-built metapackage, which speeds up total install time for about a minute, but may break when macOS version or architecture of `macos-latest` changes. The metapackage is not periodically rebuilt, so whenever you need newer versions of the dependencies, you should push a new tag and update the URL in cmake.yml.

You can fork https://github.com/l2dy/clifm-ci-files to your account and update the URL. The .mpkg file is automatically uploaded by GitHub Actions when a tag is pushed.