### PR TITLE
docs: fix simple typo, whises -> wishes

### DIFF
--- a/src/selection.c
+++ b/src/selection.c
@@ -62,7 +62,7 @@ size_t new_seln = 0; */
  * if error. This function allows the user to work with multiple
  * instances of the program: he/she can select some files in the
  * first instance and then execute a second one to operate on those
- * files as he/she whises. */
+ * files as he/she wishes. */
 int
 save_sel(void)
 {


### PR DESCRIPTION
There is a small typo in src/selection.c.

Should read `wishes` rather than `whises`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md