### PR TITLE
install man file to proper location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ elseif(UNIX)
 endif()
 
 set(BIN "clifm")
-set(_MANDIR "man/man1")
+set(_MANDIR "share/man/man1")
 set(_BASHDIR "share/bash-completion/completions")
 set(_ZSHDIR "share/zsh/site-functions")
 set(_DESKTOPPREFIX "share/applications")


### PR DESCRIPTION
`/usr/share/man` is the proper location.  see https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html