### PR TITLE
plugins-helper +x for rpmlint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ install(DIRECTORY misc/tools DESTINATION "${_PROG_DATADIR}"
 			WORLD_READ WORLD_EXECUTE)
 
 install(FILES plugins/BFG.cfg plugins/kbgen.c DESTINATION "${_PLUGINSDIR}")
-install(FILES plugins/plugins-helper DESTINATION "%{_PLUGINSDIR}"
+install(FILES plugins/plugins-helper DESTINATION "${_PLUGINSDIR}"
         PERMISSIONS
 	        OWNER_READ OWNER_WRITE OWNER_EXECUTE
 		GROUP_READ GROUP_EXECUTE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,12 @@ install(DIRECTORY misc/tools DESTINATION "${_PROG_DATADIR}"
 			GROUP_READ GROUP_EXECUTE
 			WORLD_READ WORLD_EXECUTE)
 
-install(FILES plugins/BFG.cfg plugins/kbgen.c plugins/plugins-helper DESTINATION "${_PLUGINSDIR}")
+install(FILES plugins/BFG.cfg plugins/kbgen.c DESTINATION "${_PLUGINSDIR}")
+install(FILES plugins/plugins-helper DESTINATION "%{_PLUGINSDIR}"
+        PERMISSIONS
+	        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+		GROUP_READ GROUP_EXECUTE
+		WORLD_READ WORLD_EXECUTE)
 
 install(FILES misc/actions.clifm misc/keybindings.clifm misc/mimelist.clifm misc/nets.clifm misc/prompts.clifm misc/readline.clifm misc/clifmrc DESTINATION "${_PROG_DATADIR}")
 


### PR DESCRIPTION
shell scripts must be executable for rpmlint checks to pass

```
clifm.x86_64: E: non-executable-script /usr/share/clifm/plugins/plugins-helper 644 /bin/sh
```

```
$ rpmlint -e non-executable-script
non-executable-script:
This text file contains a shebang or is located in a path dedicated for
executables, but lacks the executable bits and cannot thus be executed. If the
file is meant to be an executable script, add the executable bits, otherwise
remove the shebang or move the file elsewhere.
```