### PR TITLE
Dont shrink filenames to max_name_len in long listing mode

### DIFF
--- a/src/listing.c
+++ b/src/listing.c
@@ -469,7 +469,7 @@ get_longest_filename(const int n, const int pad)
 		file_info[i].eln_n = no_eln ? -1 : DIGINUM(i + 1);
 
 		size_t blen = file_info[i].len;
-		if (file_info[i].len > (size_t)max_name_len)
+		if (!long_view && file_info[i].len > (size_t)max_name_len)
 			file_info[i].len = (size_t)max_name_len;
 
 		total_len = (size_t)pad + 1 + file_info[i].len;


### PR DESCRIPTION
In case we switch to long listing mode, we shouldnt have short filenames as in default mode.
I think this change now matches the wiki information, and shrinks the filenames only to fit the screen (unless MinFilenameTrim is set).