### PR TITLE
Make translations of shared functions for fish

### DIFF
--- a/functions/cd_on_quit.fish
+++ b/functions/cd_on_quit.fish
@@ -1,0 +1,11 @@
+# Copy this into $HOME/.config/fish/functions/c.fish
+# Note that conventionally fish functions are named after the file they are in.
+# This works best with the fish built-in funced, funcsave, etc.
+function c --wraps=clifm --description="Change directory after exiting clifm"
+    clifm "--cd-on-quit" $argv
+    set --query XDG_CONFIG_HOME; and set --function config_home "$XDG_CONFIG_HOME"; or set --function config_home "$HOME/.config"
+    set --function dir "$(grep "^\*" "$config_home/clifm/.last" 2>/dev/null | cut -d':' -f2)"
+    if test "$dir"
+        cd -- "$dir"; or return 1
+    end
+end

--- a/functions/cd_on_quit.fish
+++ b/functions/cd_on_quit.fish
@@ -1,6 +1,17 @@
-# Copy this into $HOME/.config/fish/functions/c.fish
-# Note that conventionally fish functions are named after the file they are in.
-# This works best with the fish built-in funced, funcsave, etc.
+# CliFM CD on quit
+
+# Description
+# Run CliFM and, if the exit command is "Q" (not "q"), read the .last file and cd into it.
+#
+# 1) Customize this function as needed and copy it into your fish functions directory as a .fish file with the same name.
+#    For example, with the default name, the file should be c.fish.
+# 2) Run clifm using the name of the function below: c [ARGS ...]
+
+# Dependecies: clifm, cut, grep
+
+# Author: Spenser Black
+# License: GPL3
+
 function c --wraps=clifm --description="Change directory after exiting clifm"
     clifm "--cd-on-quit" $argv
     set --query XDG_CONFIG_HOME; and set --function config_home "$XDG_CONFIG_HOME"; or set --function config_home "$HOME/.config"

--- a/functions/file_picker.fish
+++ b/functions/file_picker.fish
@@ -4,7 +4,7 @@
 function p --wraps=clifm --description="Execute a command on the files selected using CliFM"
     set --function clifm_selfile (mktemp "/tmp/clifm_selfile.XXXXXXXXXX")
 
-    clifm --sel-file="$clifm_selfile"
+    clifm $argv --sel-file="$clifm_selfile"
 
     # NOTE: -s returns true if the size of the file is greater than zero
     if test -s "$clifm_selfile"

--- a/functions/file_picker.fish
+++ b/functions/file_picker.fish
@@ -1,6 +1,20 @@
-# Copy this into $HOME/.config/fish/functions/p.fish
-# Note that conventionally fish functions are named after the file they are in.
-# This works best with the fish built-in funced, funcsave, etc.
+# File picker function for CliFM
+
+# Usage (assuming the function is not renamed): p [ARGS ...]
+#
+# 1. CliFM will be executed: select the files you need and quit.
+# 2. You will be asked for a command to execute over selected files,
+# for example: ls -l
+#
+# Customize this function as you need and copy it to your fish functions directory.
+# Note that conventionally fish functions are named after the file they are in, so
+# with the name below, the file should be named p.fish.
+
+# Dependecies: clifm, sed, find, xargs
+
+# Author: Spenser Black
+# License: GPL3
+
 function p --wraps=clifm --description="Execute a command on the files selected using CliFM"
     set --function clifm_selfile (mktemp "/tmp/clifm_selfile.XXXXXXXXXX")
 

--- a/functions/file_picker.fish
+++ b/functions/file_picker.fish
@@ -1,0 +1,21 @@
+# Copy this into $HOME/.config/fish/functions/p.fish
+# Note that conventionally fish functions are named after the file they are in.
+# This works best with the fish built-in funced, funcsave, etc.
+function p --wraps=clifm --description="Execute a command on the files selected using CliFM"
+    set --function clifm_selfile (mktemp "/tmp/clifm_selfile.XXXXXXXXXX")
+
+    clifm --sel-file="$clifm_selfile"
+
+    # NOTE: -s returns true if the size of the file is greater than zero
+    if test -s "$clifm_selfile"
+        set --function cmd ""
+        while test -z "$cmd"
+            read --function --prompt-str "Enter command ('q' to quit): " cmd
+        end
+        test "$cmd" = "q"; and return
+        sed 's/ /\\ /g' "$clifm_selfile" | xargs $cmd
+        rm -- "$clifm_selfile"
+    else
+        printf "clifm: No selected files\n" >&2
+    end
+end


### PR DESCRIPTION
The one thing I didn't translate was `subshell_notice.sh`. The way to accomplish changing the prompt would be to edit `$HOME/.config/fish/fish_prompt.fish`. There are multiple built-in prompts, and even the default is pretty complex, so it's not much of a simple copy-and-paste job. Seemed to me like it would be better to refer fish users to documentation than provide code to copy-and-paste for this one.

But a simple prompt would be like
```fish
function fish_prompt
    set --local suffix ">"
    set --query CLIFM; and set --local suffix "(clifm)$suffix"
    echo -n -s "$suffix"
end
```

Also, I changed `file_picker` to use `$argv` instead of passing a `CLIFM_OPTIONS` variable. I'm not really sure what the purpose was in the original script, but I'm guessing the intent was to allow somebody to pass additional CLI options with that variable? If so, using `$argv` is more idiomatic for fish IMO, since these functions "wrap" clifm.

One interesting thing about fish is that it reads from a `$HOME/.config/fish/functions` directory, which means installation is as simple as copying these files to that directory. That opens up the possibility of a script like `install-extensions.fish` to automatically copy these files.