### PR TITLE
Add more entries to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,10 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.py]
+indent_style = space
+indent_size = 4
+
 [*.{yaml,yml}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,10 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.fish]
+indent_style = space
+indent_size = 4
+
 [*.py]
 indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
- Use 2-space indentation for YAML
- Use 4-space indentation for Python
- Use 4-space indentation for Fish

Related: https://github.com/leo-arch/clifm/issues/239#issuecomment-1744871318
