### PR TITLE
Don't compress man page(s) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ install: $(BIN)
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(DESKTOPPREFIX)
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(DESKTOPICONPREFIX)/scalable/apps
 	$(INSTALL) -m 0644 misc/manpage $(DESTDIR)$(MANDIR)/man1/$(BIN).1
-	gzip -f -- $(DESTDIR)$(MANDIR)/man1/$(BIN).1
 	$(INSTALL) -m 0644 misc/completions.bash $(DESTDIR)$(DATADIR)/bash-completion/completions/$(BIN)
 	$(INSTALL) -m 0644 misc/completions.zsh $(DESTDIR)$(DATADIR)/zsh/site-functions/_$(BIN)
 	$(INSTALL) -m 0644 misc/completions.fish $(DESTDIR)$(DATADIR)/fish/vendor_completions.d/$(BIN).fish


### PR DESCRIPTION
Hello :wave:,

Compressing man pages is a distribution / user preference that should be handled on the packaging side of things.

Indeed, compressing man pages by default imposes a compression algorithm / level whereas most package managers handle that already and eventually allow users to choose or customize them if wanted.

Additionally, it can lead to unexpected side effects. For instance, gzip is recording timestamps in metadata by default, which prevents [reproducible builds](https://reproducible-builds.org/):

```
==> ERROR: Package is not reproducible
--- clifm-1.24-1-x86_64.pkg.tar.zst
+++ ./build/clifm-1.24-1-x86_64.pkg.tar.zst
├── clifm-1.24-1-x86_64.pkg.tar
│ ├── .MTREE
│ │ ├── .MTREE-content
│ │ │ @@ -93,11 +93,11 @@
│ │ │  ./usr/share/icons time=1741602156.0 type=dir
│ │ │  ./usr/share/icons/hicolor time=1741602156.0 type=dir
│ │ │  ./usr/share/icons/hicolor/scalable time=1741602156.0 type=dir
│ │ │  ./usr/share/icons/hicolor/scalable/apps time=1741602156.0 type=dir
│ │ │  ./usr/share/icons/hicolor/scalable/apps/clifm.svg time=1741602156.0 mode=644 size=3919 sha256digest=01f31891701bcf9b405a5c63840077976b04a25e32240ac31faf8ab61cdd4479
│ │ │  ./usr/share/man time=1741602156.0 type=dir
│ │ │  ./usr/share/man/man1 time=1741602156.0 type=dir
│ │ │ -./usr/share/man/man1/clifm.1.gz time=1741602156.0 mode=644 size=67839 sha256digest=f242c85d1e790656435f69fa73a333340b982f50c9e50da139d681307d98e4a6
│ │ │ +./usr/share/man/man1/clifm.1.gz time=1741602156.0 mode=644 size=67839 sha256digest=8ac04a5276bee8e0baebb7ca6b8665f4b76ab2143bc066717e709ec199a3f76c
│ │ │  ./usr/share/zsh time=1741602156.0 type=dir
│ │ │  ./usr/share/zsh/site-functions time=1741602156.0 type=dir
│ │ │  ./usr/share/zsh/site-functions/_clifm time=1741602156.0 mode=644 size=7983 sha256digest=d051d2af1a7f4030e7c5ab2d8aa924e70e5ab3c3b2bb93013801d6e4cbc96baf
│ ├── usr/share/man/man1/clifm.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "clifm.1", last modified: Mon Mar 10 10:22:48 2025, from Unix
│ │ │ +gzip compressed data, was "clifm.1", last modified: Mon Mar 10 10:24:03 2025, from Unix
```

See https://cmpct.info/~sam/blog/posts/automatic-manpage-compression/ for detailed rational.