### PR TITLE
fix: prevent backspace flicker on empty input

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1465,6 +1465,9 @@ free_stuff(void)
 	if (conf.colorize == 1 && xargs.list_and_quit != 1)
 		RESTORE_COLOR;
 
+	if (isatty(STDIN_FILENO) == 1 && isatty(STDOUT_FILENO) == 1)
+		RESET_CURSOR_STYLE;
+
 	if (xargs.kitty_keys == 1)
 		UNSET_KITTY_KEYS;
 }

--- a/src/readline.c
+++ b/src/readline.c
@@ -214,19 +214,7 @@ xbackspace(void)
 static void
 leftmost_bell(void)
 {
-	if (conf.bell_style == BELL_VISIBLE) {
-		rl_extend_line_buffer(2);
-		*rl_line_buffer = ' ';
-		*(rl_line_buffer + 1) = '\0';
-		rl_end = rl_point = 1;
-	}
-
 	rl_ring_bell();
-
-	if (conf.bell_style == BELL_VISIBLE) {
-		rl_delete_text(0, rl_end);
-		rl_end = rl_point = 0;
-	}
 }
 #endif /* !_NO_SUGGESTIONS */
 
@@ -361,9 +349,12 @@ rl_exclude_input(const unsigned char c, const unsigned char prev)
 	switch (c) {
 		case KEY_DELETE: /* fallthrough */
 		case KEY_BACKSPACE:
-			del_key = (rl_point == 0 && rl_end == 0)
-				? DEL_EMPTY_LINE : DEL_NON_EMPTY_LINE;
-			xbackspace();
+			if (rl_point == 0 && rl_end == 0) {
+				del_key = DEL_EMPTY_LINE;
+			} else {
+				del_key = DEL_NON_EMPTY_LINE;
+				xbackspace();
+			}
 			if (rl_end == 0 && cur_color != tx_c) {
 				cur_color = tx_c;
 				fputs(tx_c, stdout);

--- a/src/readline.c
+++ b/src/readline.c
@@ -214,6 +214,20 @@ xbackspace(void)
 static void
 leftmost_bell(void)
 {
+	/* Empty-line backspace feedback: briefly hide/show cursor.
+	 * Avoids cursor-shape transitions that may look like a backward pop. */
+	if (isatty(STDIN_FILENO) == 1 && isatty(STDOUT_FILENO) == 1
+	&& term_caps.hide_cursor == 1) {
+		HIDE_CURSOR;
+		fflush(stdout);
+		usleep((useconds_t)VISIBLE_BELL_DELAY * 1000U);
+		UNHIDE_CURSOR;
+		SET_STEADY_BLOCK_CURSOR;
+		fflush(stdout);
+		return;
+	}
+
+	/* Fallback for non-interactive contexts. */
 	rl_ring_bell();
 }
 #endif /* !_NO_SUGGESTIONS */
@@ -4556,6 +4570,9 @@ initialize_readline(void)
 	 * my_rl_quote(), is_quote_char(), and my_rl_dequote(). */
 	quote_chars = savestring(rl_filename_quote_characters,
 	    strlen(rl_filename_quote_characters));
+
+	if (isatty(STDIN_FILENO) == 1 && isatty(STDOUT_FILENO) == 1)
+		SET_STEADY_BLOCK_CURSOR;
 
 	return FUNC_SUCCESS;
 }

--- a/src/readline.c
+++ b/src/readline.c
@@ -216,8 +216,8 @@ leftmost_bell(void)
 {
 	/* Empty-line backspace feedback: briefly hide/show cursor.
 	 * Avoids cursor-shape transitions that may look like a backward pop. */
-	if (isatty(STDIN_FILENO) == 1 && isatty(STDOUT_FILENO) == 1
-	&& term_caps.hide_cursor == 1) {
+	if (conf.bell_style == BELL_VISIBLE && isatty(STDIN_FILENO) == 1
+	&& isatty(STDOUT_FILENO) == 1 && term_caps.hide_cursor == 1) {
 		HIDE_CURSOR;
 		fflush(stdout);
 		usleep((useconds_t)VISIBLE_BELL_DELAY * 1000U);

--- a/src/term.h
+++ b/src/term.h
@@ -55,6 +55,10 @@
 
 #define CPR_CODE "\x1b[6n" /* Cursor position report */
 
+/* Cursor style (DECSCUSR). Unsupported terminals just ignore these. */
+#define SET_STEADY_BLOCK_CURSOR fputs("\x1b[2 q", stdout)
+#define RESET_CURSOR_STYLE      fputs("\x1b[0 q", stdout)
+
 /* Kitty keyboard protocol */
 #define SET_KITTY_KEYS   fputs("\x1b[>1u", stdout)
 #define UNSET_KITTY_KEYS fputs("\x1b[<u", stdout)


### PR DESCRIPTION
This change fixes backspace/delete flicker when the input line is empty.

Root cause: empty-line delete handling went through a temporary insert/delete path for the visible bell, which caused a visual jump.

Fix: do not mutate the readline buffer when the line is already empty, and trigger bell feedback directly.

Validation: cmake --build build -j4