### PR TITLE
fix: make Ctrl-C clear current input line

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -269,11 +269,18 @@ run_action(char *action, char **args)
 	/* Wait for the child to finish. Otherwise, the child is left as a
 	 * zombie process. Store plugin exit status in EXIT_STATUS. */
 	int status = 0;
-	if (waitpid(pid, &status, 0) > 0) {
-		exit_status = get_exit_code(status, EXEC_FG_PROC);
-	} else {
+	while (1) {
+		if (waitpid(pid, &status, 0) > 0) {
+			exit_status = get_exit_code(status, EXEC_FG_PROC);
+			break;
+		}
+
+		if (errno == EINTR)
+			continue;
+
 		exit_status = errno;
 		xerror("actions: waitpid: %s\n", strerror(errno));
+		break;
 	}
 
 	/* If the pipe is empty */

--- a/src/readline.c
+++ b/src/readline.c
@@ -4517,6 +4517,9 @@ initialize_readline(void)
 	/* Set the name of the program using readline. Mostly used for
 	 * conditional constructs in the inputrc file. */
 	rl_readline_name = PROGRAM_NAME;
+	/* Keep signal/control-char handling consistent with CliFM's custom
+	 * Ctrl+c clear-line implementation. */
+	rl_catch_signals = 0;
 
 	disable_rl_conflicting_kbinds();
 	set_rl_init_file();

--- a/src/readline.c
+++ b/src/readline.c
@@ -78,6 +78,31 @@ static int tagged_files_n = 0;
 static int cb_running = 0;
 static char rl_default_answer = 0;
 
+static void
+clear_current_line_on_interrupt(void)
+{
+#ifndef _NO_SUGGESTIONS
+	if (wrong_cmd == 1)
+		recover_from_wrong_cmd();
+
+	if (suggestion.printed && suggestion_buf)
+		clear_suggestion(CS_FREEBUF);
+#endif /* !_NO_SUGGESTIONS */
+
+#ifndef _NO_HIGHLIGHT
+	if (cur_color != tx_c) {
+		cur_color = tx_c;
+		fputs(cur_color, stdout);
+	}
+#endif /* !_NO_HIGHLIGHT */
+
+	if (rl_end > 0)
+		rl_delete_text(0, rl_end);
+
+	rl_point = rl_end = 0;
+	rl_redisplay();
+}
+
 static const char *
 gen_yes_no_str(char def_answer, int allow_all)
 {
@@ -343,6 +368,11 @@ rl_exclude_input(const unsigned char c, const unsigned char prev)
 			recover_from_wrong_cmd();
 #endif /* !_NO_SUGGESTIONS */
 		return RL_INSERT_CHAR;
+	}
+
+	if (c == CTRL('C')) {
+		clear_current_line_on_interrupt();
+		return SKIP_CHAR_NO_REDISPLAY;
 	}
 
 	/* Skip control characters (0 - 31) except backspace (8), tab(9),
@@ -630,8 +660,8 @@ my_rl_getc(FILE *stream)
 			return (EOF);
 
 		  /* If the error that we received was SIGINT, then try again,
-		 this is simply an interrupted system call to read().
-		 Otherwise, some error ocurred, also signifying EOF. */
+		 this is simply an interrupted system call to read(). */
+		clear_current_line_on_interrupt();
 	}
 }
 
@@ -696,8 +726,8 @@ alt_rl_getc(FILE *stream)
 			return (EOF);
 
 		  /* If the error that we received was SIGINT, then try again,
-		 this is simply an interrupted system call to read().
-		 Otherwise, some error occurred, also signifying EOF. */
+		 this is simply an interrupted system call to read(). */
+		clear_current_line_on_interrupt();
 	}
 }
 

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -44,8 +44,14 @@ run_in_foreground(const pid_t pid)
 	int status = 0;
 
 	/* The parent process calls waitpid() on the child */
-	if (waitpid(pid, &status, 0) > 0)
-		return get_exit_code(status, EXEC_FG_PROC);
+	while (1) {
+		if (waitpid(pid, &status, 0) > 0)
+			return get_exit_code(status, EXEC_FG_PROC);
+
+		if (errno == EINTR)
+			continue;
+		break;
+	}
 
 	/* waitpid() failed */
 	const int ret = errno;
@@ -58,7 +64,13 @@ run_in_background(const pid_t pid)
 {
 	int status = 0;
 
-	if (waitpid(pid, &status, WNOHANG) == -1) {
+	while (1) {
+		if (waitpid(pid, &status, WNOHANG) != -1)
+			break;
+
+		if (errno == EINTR)
+			continue;
+
 		const int ret = errno;
 		xerror("%s: waitpid: %s\n", PROGRAM_NAME, strerror(errno));
 		return ret;
@@ -114,8 +126,13 @@ xsystem(const char *cmd)
 		execl(shell_path, shell_name, "-c", cmd, NULL);
 		_exit(errno);
 	} else {
-		if (waitpid(pid, &status, 0) == pid)
-			return status;
+		while (1) {
+			if (waitpid(pid, &status, 0) == pid)
+				return status;
+
+			if (errno != EINTR)
+				break;
+		}
 
 		return (-1);
 	}

--- a/src/term.c
+++ b/src/term.c
@@ -23,7 +23,7 @@
 #include <errno.h>
 
 #include "aux.h" /* xatoi */
-#include "misc.h" /* set_signals_to_ignore, handle_stdin */
+#include "misc.h" /* handle_stdin */
 #include "term_info.h"
 
 static struct termios bk_term_attrs;
@@ -97,8 +97,15 @@ sigwinch_handler(int sig)
 }
 #endif /* !_BE_POSIX */
 
+/* Trigger EINTR on blocking reads so the caller can handle Ctrl+c explicitly. */
 static void
-set_signals_to_ignore(void)
+sigint_handler(int sig)
+{
+	UNUSED(sig);
+}
+
+static void
+set_shell_signal_handlers(void)
 {
 	struct sigaction sa;
 
@@ -107,14 +114,20 @@ set_signals_to_ignore(void)
 	sa.sa_flags = SA_RESTART;
 	sa.sa_handler = SIG_IGN;
 
-	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGQUIT, &sa, NULL);
 	sigaction(SIGTSTP, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
 	sigaction(SIGTTIN, &sa, NULL);
 	sigaction(SIGTTOU, &sa, NULL);
 
+	memset(&sa, 0, sizeof(sa));
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sa.sa_handler = sigint_handler;
+	sigaction(SIGINT, &sa, NULL);
+
 #ifndef _BE_POSIX
+	sa.sa_flags = SA_RESTART;
 	sa.sa_handler = sigwinch_handler;
 	sigaction(SIGWINCH, &sa, NULL);
 #endif /* !_BE_POSIX */
@@ -134,7 +147,7 @@ init_shell(void)
 	}
 
 	own_pid = get_own_pid();
-	set_signals_to_ignore();
+	set_shell_signal_handlers();
 }
 
 /* Set the terminal into raw mode. Return 0 on success and -1 on error */


### PR DESCRIPTION
## Summary
- make `Ctrl+C` clear the current prompt input line instead of being ignored
- keep external foreground command signal behavior intact

## Root Cause
`SIGINT` was ignored in the interactive shell process, so pressing `Ctrl+C` during prompt input did not trigger line reset behavior.

## Changes
- install a dedicated `SIGINT` handler in terminal setup so blocked reads can observe interrupt events
- add a shared readline helper to clear prompt state and redraw
- handle both interrupt paths for consistency:
  - direct `Ctrl+C` input handling in readline
  - `read()` interrupted with `EINTR`
- normalize `waitpid()` loops to retry on `EINTR` where needed (`spawn.c`, `actions.c`)
- rename signal setup function for clearer intent and consistency

## Verification
- `cmake --build build -j4`
- manual PTY regression check for prompt-line clear behavior after interrupt
