### PR TITLE
removal of `tmppath` from set_pledge

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1190,7 +1190,7 @@ set_security_paranoid_mode(void)
 static inline void
 set_pledge(void)
 {
-	if (pledge("stdio rpath wpath cpath dpath tmppath fattr "
+	if (pledge("stdio rpath wpath cpath dpath fattr "
 	"chown flock getpw tty proc exec", NULL) == -1) {
 		fprintf(stderr, "%s: pledge: %s\n", PROGRAM_NAME, strerror(errno));
 		exit(errno);


### PR DESCRIPTION
`tmppath` is no longer available for `pledge`, and requires removal to prevent clifm from crashing.