### PR TITLE
Fix Darwin build with Homebrew dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ######################
 
 OS != uname -s
+OS ?= $(shell uname -s)
 
 BIN ?= clifm
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LIBS_FreeBSD ?= -I/usr/local/include -L/usr/local/lib -lreadline -lintl -lmagic
 LIBS_DragonFly ?= -I/usr/local/include -L/usr/local/lib -lreadline -lintl -lmagic
 LIBS_NetBSD ?= -I/usr/pkg/include -I/usr/pkg/include/gettext -L/usr/pkg/lib -Wl,-R/usr/pkg/lib -lreadline -lintl -lmagic -lutil
 LIBS_OpenBSD ?= -I/usr/local/include -L/usr/local/lib -lereadline -lintl -lmagic
-LIBS_Darwin ?= -I/opt/local/include -L/opt/local/lib -lreadline -lintl -lmagic
+LIBS_Darwin ?= -I/opt/homebrew/opt/readline/include -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/opt/libmagic/include -I/opt/local/include -L/opt/homebrew/opt/readline/lib -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/opt/libmagic/lib -L/opt/local/lib -lreadline -lintl -lmagic
 
 $(BIN): $(SRC) $(HEADERS)
 	@printf "Detected operating system: %s\n" "$(OS)"


### PR DESCRIPTION
## Summary
- Add a GNU make fallback for OS detection when `OS != uname -s` leaves `OS` empty
- Add Apple Silicon Homebrew dependency paths to the Darwin Makefile flags
- Keep the existing MacPorts `/opt/local` fallback paths after Homebrew paths
- Ensure Homebrew readline headers are preferred over macOS libedit compatibility headers

## Verification
- `make --version`
- `make -B -n`
- `gmake -B -n`
- `make -B -n OS=Linux`
- `make -B -n OS=FreeBSD`
- `make -B -n OS=OpenBSD`
- `make -B -n OS=Darwin LIBS_Darwin="-lcustom"`
- `make clean && make`
- `./clifm --version`
- `otool -L ./clifm`
- `git diff --check`

## Notes
The default `/usr/bin/make` on this macOS system is GNU Make 3.81. It does not evaluate the BSD-style `OS != uname -s` assignment, so plain `make` left `OS` empty and skipped `LIBS_Darwin`. The added `OS ?= $(shell uname -s)` keeps the existing BSD make assignment while providing a GNU make fallback.

On Darwin, Homebrew paths are placed before `/opt/local` so Apple Silicon Homebrew builds use GNU readline/gettext/libmagic instead of the system libedit readline compatibility headers or missing gettext headers.
