### PR TITLE
Add CwdInTitle configuration file option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2008,8 +2008,12 @@ create_main_config_file(char *file)
 # append file type indicator to filenames.\n\
 ;Classify=%s\n\n"
 
-		"# Colorize symbolic links according to their target filename.\n\
+	    "# Colorize symbolic links according to their target filename.\n\
 ;ColorLinksAsTarget=%s\n\n"
+
+	    "# Show the current working directory in the terminal title.\n\
+;CwdInTitle=%s\n\n"
+
 
 	    "# Share the Selection Box among different profiles.\n\
 ;ShareSelbox=%s\n\n"
@@ -2072,6 +2076,7 @@ create_main_config_file(char *file)
 		DEF_LIGHT_MODE == 1 ? "true" : "false",
 		DEF_CLASSIFY == 1 ? "true" : "false",
 		DEF_COLORIZE_LNK_AS_TARGET == 1 ? "true" : "false",
+		DEF_CWD_IN_TITLE == 1 ? "true" : "false",
 		DEF_SHARE_SELBOX == 1 ? "true" : "false",
 		DEF_TERM_CMD,
 		DEF_SORT_REVERSE == 1 ? "true" : "false",
@@ -3663,6 +3668,11 @@ read_config(void)
 		else if (!conf.usr_cscheme && *line == 'C'
 		&& strncmp(line, "ColorScheme=", 12) == 0) {
 			set_colorscheme(line + 12);
+		}
+
+		else if (xargs.cwd_in_title == UNSET && *line == 'C'
+		&& strncmp(line, "CwdInTitle=", 12) == 0) {
+			set_config_bool_value(line + 12, &xargs.cwd_in_title);
 		}
 
 		else if (*line == 'c' && strncmp(line, "cpCmd=", 6) == 0) {


### PR DESCRIPTION
## Summary

- Add `CwdInTitle` as a persistent configuration file option in clifmrc

## Changes

| File | Change |
|------|--------|
| `src/config.c` | Add config parser entry and default template entry for CwdInTitle |

## Details

The `--cwd-in-title` CLI flag was deprecated, but there was no way to
persistently enable this feature via the configuration file.

This adds:
1. A `CwdInTitle=true/false` option readable from clifmrc
2. The option in the default config file template
3. Follows the existing pattern for boolean config options

## Test Plan

- [ ] Add `CwdInTitle=true` to clifmrc and verify the terminal title shows the cwd
- [ ] Verify CLI flag still works (takes precedence over config)
- [ ] Verify default (false) behavior is unchanged when option is absent

Closes #316